### PR TITLE
Add option to only show tasks that are due

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -74,15 +74,17 @@ Typical example of using this card in YAML config would look like this:
 type: 'custom:todoist-card'
 entity: sensor.to_do_list
 show_header: true
+only_today_overdue: false
 ```
 
 Here is what every option means:
 
-| Name           |   Type    | Default      | Description                                                    |
-| -------------- | :-------: | :----------: | ---------------------------------------------------------------|
-| `type`         | `string`  | **required** | `custom:todoist-card`                                          |
-| `entity`       | `string`  | **required** | An entity_id within the `sensor` domain.                       |
-| `show_header`  | `boolean` | `true`       | Show friendly name of the selected `sensor` in the card header.|
+| Name                 |   Type    |   Default    | Description                                                     |
+| -------------------- | :-------: | :----------: | --------------------------------------------------------------- |
+| `type`               | `string`  | **required** | `custom:todoist-card`                                           |
+| `entity`             | `string`  | **required** | An entity_id within the `sensor` domain.                        |
+| `show_header`        | `boolean` |    `true`    | Show friendly name of the selected `sensor` in the card header. |
+| `only_today_overdue` | `boolean` |   `false`    | Only show tasks that are overdue or due today.                  |
 
 ## Actions
 

--- a/todoist-card.js
+++ b/todoist-card.js
@@ -23,6 +23,14 @@ class TodoistCardEditor extends LitElement {
         
         return true;
     }
+
+    get _only_today_overdue() {
+        if (this._config) {
+            return this._config.only_today_overdue || false;
+        }
+        
+        return false;
+    }
     
     setConfig(config) {
         this._config = config;
@@ -103,6 +111,16 @@ class TodoistCardEditor extends LitElement {
                 >
                 </ha-switch>
                 Show header
+            </p>
+
+            <p class="option">
+                <ha-switch
+                    .checked=${(this._config.only_today_overdue !== undefined) && (this._config.only_today_overdue !== false)}
+                    .configValue=${'only_today_overdue'}
+                    @change=${this.valueChanged}
+                >
+                </ha-switch>
+                Only show today or overdue
             </p>
         </div>`;
     }
@@ -248,6 +266,9 @@ class TodoistCard extends LitElement {
         }
         
         let items = state.attributes.items || [];
+        if (this.config.only_today_overdue) {
+            items = items.filter(item => (new Date() >= new Date(item.due.date)));
+        }
         
         return html`<ha-card>
             ${(this.config.show_header === undefined) || (this.config.show_header !== false)


### PR DESCRIPTION
Came across your todoist-card and quickly added an additional option to only show tasks that are due today or overdue.