### PR TITLE
fixing project name for quick add

### DIFF
--- a/todoist-card.js
+++ b/todoist-card.js
@@ -337,7 +337,7 @@ class TodoistCard extends LitElement {
                         this.hass
                             .callService('rest_command', 'todoist', {
                                 url: 'quick/add',
-                                payload: 'text=' + value + ' #' + state.attributes.project.name,
+                                payload: 'text=' + value + ' #' + state.attributes.project.name.replaceAll(' ',''),
                             })
                             .then(response => {
                                 input.value = '';


### PR DESCRIPTION
If you use quick add and your project name has spaces, it only uses the first word.

From the documentation... [a project name starting with the # character (without spaces)](https://developer.todoist.com/sync/v8/#quick-add-an-item)

Note that I haven't been able to test the script change in HASS... I just got started and can't figure out how to test script changes for custom components.  If you need that first, I can figure out how to... I just wanted to submit this while I had a sec.